### PR TITLE
add all supported domains

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Options Songlink for Chrome</title>
-    <meta name="description" content="Options for Songlink Chrome extension">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" type="image/x-icon" href="favicon.png">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Options for Songlink for Chrome</title>
+    <meta name="description" content="Options for Songlink Chrome extension" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.png" />
     <style type="text/css">
-      body{
+      body {
         font-family: sans-serif;
         margin: 0;
         padding: 15px 20px;
@@ -18,17 +18,17 @@
 
   <body>
     <div class="options">
-      <p><strong>Choose what the songlink button should do :</strong></p>
+      <p><strong>Choose what the Songlink button should do:</strong></p>
       <p>
         <label>
-          <input type="checkbox" id="copyToClipboard" name="copytoclipboard">
-          Copy songlink to clipboard
+          <input type="checkbox" id="copyToClipboard" name="copytoclipboard" />
+          Copy Songlink URL to clipboard
         </label>
       </p>
       <p>
         <label>
-          <input type="checkbox" id="openNewTab" name="openNewTab">
-          Open songlink in new tab
+          <input type="checkbox" id="openNewTab" name="openNewTab" /> Open
+          Songlink in new tab
         </label>
       </p>
       <div id="status"></div>


### PR DESCRIPTION
This PR introduces the following changes:

- add all supported domains
- factored out logic for determining support into shareable `isSupportedUrl` function
- removed platform-specific logic for creating Songlink URL, except for Google Play Music
- accidentally had `prettier` running in my editor, so some spacing and formatting got changed. Let me know if you'd like me to go through and revert
- minor tweaks to content in `options.html` file

I tested locally with both Google Play pages and non-Google Play pages. Everything seems to be working well. Let me know if you want me to change or fix anything. Should I bump the version in the package.json? Or you will do it in a separate change once this is merged?
