### PR TITLE
add support for new music.apple.com URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
       "matches": [
         "https://*.song.link/*",
         "*://itunes.apple.com/*",
+        "*://music.apple.com/*",
         "*://*.itun.es/*",
         "*://*.spotify.com/*",
         "*://*.youtube.com/*",

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ window.browser = (function () {
 var supportedDomains = [
   'song.link/',
   'itunes.apple.com/',
+  'music.apple.com/',
   'itun.es/',
   'open.spotify.com/track/',
   'open.spotify.com/album/',


### PR DESCRIPTION
As of yesterday, Apple now uses music.apple.com URLs. They even switched the IDs of every single entity! And a few other changes... yesterday was rough 😏

I don't know how much this affects the extension, bc most Apple Music do not use the web (and you can't really use it in a browser anyway), but we should support as best as possible.